### PR TITLE
add nodeproto as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nodeproto"]
+	path = nodeproto
+	url = https://github.com/noahehall/nodeproto


### PR DESCRIPTION
- spike of using git submodules for consuming nodeprot
- i've never used submodules (personally or professionaly), but i use git for everything so what could go wrong?


- if this doesnt work, check create-react-app internals, i might have to build something similar,
- remember the horrible experience of consuming microsofts monorepo thing